### PR TITLE
Вибір того самого дня в датапікерах; вибір роки лише після вибору країни

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -11,7 +11,8 @@ export class Datepicker {
 		const startDateValue = Datepicker.getDate(this.#startLink);
 		if (startDateValue) {
 			let minEnabledDay = new Date(startDateValue);
-			minEnabledDay.setDate(minEnabledDay.getDate() + 1);
+			minEnabledDay.setDate(minEnabledDay.getDate());
+			// minEnabledDay.setDate(minEnabledDay.getDate() + 1);
 			this.#endLink.datepicker("option", "minDate", minEnabledDay);
 			return;
 		}
@@ -23,7 +24,8 @@ export class Datepicker {
 		const endDateValue = Datepicker.getDate(this.#endLink);
 		if (endDateValue) {
 			let maxEnabledDay = new Date(endDateValue);
-			maxEnabledDay.setDate(maxEnabledDay.getDate() - 1);
+			maxEnabledDay.setDate(maxEnabledDay.getDate());
+			// maxEnabledDay.setDate(maxEnabledDay.getDate() - 1);
 			this.#startLink.datepicker("option", "maxDate", maxEnabledDay);
 			return;
 		}

--- a/js/handler.js
+++ b/js/handler.js
@@ -25,6 +25,7 @@ import { showErrorHeaderMessage } from "./errors.js";
 const blockResultsHolidays = document.querySelector("#holidays-results");
 const selectedCountryBlock = document.querySelector("#selectedCountry");
 const selectedYearBlock = document.querySelector("#selectedYear");
+export const requestButton = document.querySelector("button#get-holidays");
 
 export const buttonPresetWeekHandler = (event) => {
     datepicker.setEndDateByPreset("week");
@@ -48,6 +49,13 @@ export const calculateButtonHandler = () => {
     addNewLi({ ...arg, value });
     datepicker.setDate();
     checkIsDisabledButton()
+}
+
+export const countrySelectHandler = ({target : { value }}) => {
+    if(value !== "") {
+        yearSelect.disabled = false;
+        requestButton.disabled = false;
+    }
 }
 
 export const handleRequestHolidays = async () => {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -21,8 +21,6 @@ const buttonPresetWeek = document.getElementById("setWeek");
 const buttonPresetMonth = document.getElementById("setMonth");
 export const countriesSelect = document.getElementById("country");
 export const yearSelect = document.getElementById("year");
-export const requestButton = document.querySelector("button#get-holidays");
-
 export const checkIsDisabledButton = (valueStart, valueEnd) => {
     calculateButton.disabled = !(valueStart && valueEnd);;
 }
@@ -31,13 +29,6 @@ export const checkIsDisabledPresets = (value) => {
     let isDateSelected = !!value;
     buttonPresetMonth.disabled = !isDateSelected;
     buttonPresetWeek.disabled = !isDateSelected;
-}
-
-export const checkIsCanGetHolidays = () => {
-    if (countriesSelect.value !== "" && yearSelect.value !== "") {
-        requestButton.disabled = false;
-        return;
-    }
 }
 
 const getStringStates = (obj) => {
@@ -123,7 +114,7 @@ const createOptionsCountries = (countries) => {
     countries.forEach((country) => {
         addOption(countriesSelect, country["iso-3166"], country["country_name"]);
     });
-    countriesSelect.value = "UA";
+    // countriesSelect.value = "UA";
 }
 
 const createOptionsYears = (start, end) => {
@@ -131,6 +122,7 @@ const createOptionsYears = (start, end) => {
         addOption(yearSelect, i, i);
     };
     yearSelect.value = (new Date()).getFullYear();
+    yearSelect.disabled = true;
 }
 
 const updateListCountries = async () => {
@@ -157,7 +149,6 @@ export const initSelects = async () => {
     const countries = await getListCountries();
     createOptionsCountries(countries);
     createOptionsYears(2001, 2049);
-    checkIsCanGetHolidays();
 }
 
 export const sortItemHolidays = (a, b, direction) => {

--- a/js/index.js
+++ b/js/index.js
@@ -4,19 +4,19 @@ import {
 	checkIsDisabledButton,
 	buttonPresetMonth,
 	buttonPresetWeek,
-	checkIsCanGetHolidays,
 	countriesSelect,
 	yearSelect,
-	requestButton,
 	initSelects,
-	initTabActive
+	initTabActive	
 } from "./helpers.js";
 import {
+	requestButton,
 	calculateButtonHandler,
 	buttonPresetMonthHandler,
 	buttonPresetWeekHandler,
 	handleRequestHolidays,
 	sortButtonHandler,
+	countrySelectHandler,
 	langHandler
 } from "./handler.js"
 import { Datepicker } from "./datepicker.js";
@@ -25,6 +25,7 @@ import { showErrorHeaderMessage } from "./errors.js";
 // Get the DOM elements
 const calculateButton = document.getElementById("calculateButton");
 const sortButton = document.getElementById("holiday-sort");
+const langPicker = document.getElementById("langpicker");
 
 let datepicker;
 // Initialization 
@@ -47,10 +48,9 @@ initTabActive();
 buttonPresetWeek.addEventListener("click", buttonPresetWeekHandler);
 buttonPresetMonth.addEventListener("click", buttonPresetMonthHandler);
 calculateButton.addEventListener("click", calculateButtonHandler);
-countriesSelect.addEventListener("change", checkIsCanGetHolidays);
-yearSelect.addEventListener("change", checkIsCanGetHolidays);
+countriesSelect.addEventListener("change", countrySelectHandler);
 requestButton.addEventListener("click", handleRequestHolidays);
 sortButton.addEventListener("click", sortButtonHandler);
-document.getElementById("langpicker").addEventListener("click", langHandler)
+langPicker.addEventListener("click", langHandler);
 
 export { datepicker };


### PR DESCRIPTION
Готувалася до завтрашнього захисту - знайшла неточності з технічним завданням. 
1. _"Тільки після того як юзер обрав одну дату в першому інпуті, він може обрати дату в другому інпуті яка йде не раніше дати з першого інпуту і навпаки"_ - а в мене можна було вибрати лише наступну чи попередню дату; виправила, щоб можна було вибрати ту ж.
2. _"В другому інпуті 'Вибір року' має бути список років від 2001 до 2049. Цей інпут має бути заблокований доки юзер не обере країну"_ - в мене були доступними обидва відразу.